### PR TITLE
add a new policy for workload

### DIFF
--- a/ocp_workload_policy.te
+++ b/ocp_workload_policy.te
@@ -1,0 +1,28 @@
+# Copyright 2023 Intel Corporation. All Rights Reserved.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+policy_module(ocp_workload_policy, 1.0)
+
+gen_require(`
+        type container_device_t;
+        type dri_device_t;
+')
+
+#============= container_device_t ==============
+
+#!!!! This avc can be allowed using the boolean 'container_use_devices'
+allow container_device_t dri_device_t:chr_file map;
+

--- a/user-container-selinux-policy.Dockerfile
+++ b/user-container-selinux-policy.Dockerfile
@@ -28,7 +28,7 @@ RUN dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-
     make -f /usr/share/selinux/devel/Makefile
 
 RUN install -D ${DIR}/LICENSE /install_root/licenses/user-container-selinux/LICENSE && \
-    install -D ${DIR}/container_device.pp /install_root/opt/selinux-policy/container_device.pp
+    install -D ${DIR}/ocp_workload_policy.pp /install_root/opt/selinux-policy/ocp_workload_policy.pp
 
 FROM ${FINAL_BASE}
 
@@ -45,4 +45,4 @@ RUN microdnf upgrade && \
 
 COPY --from=builder /install_root /
 
-ENTRYPOINT [ "/bin/sh", "-c", "semodule -i /opt/selinux-policy/container_device.pp" ]
+ENTRYPOINT [ "/bin/sh", "-c", "semodule -i /opt/selinux-policy/ocp_workload_policy.pp" ]


### PR DESCRIPTION
Adds a new policy that is required by gpu workload to run in OpenShift. This policy gives the required access to dri_device_t